### PR TITLE
Replace undent with ruby-2.3 squiggly heredoc

### DIFF
--- a/HomebrewFormula/elasticsearch@1.7.rb
+++ b/HomebrewFormula/elasticsearch@1.7.rb
@@ -64,7 +64,7 @@ class ElasticsearchAT17 < Formula
     ln_s etc/"elasticsearch", prefix/"config"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Data:    #{var}/elasticsearch/#{cluster_name}/
     Logs:    #{var}/log/elasticsearch/#{cluster_name}.log
     Plugins: #{var}/lib/elasticsearch/plugins/


### PR DESCRIPTION
Fixing a deprecation warning.

```
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/garrow/homebrew-elasticsearch17/HomebrewFormula/elasticsearch@1.7.rb:72:in `caveats'
Please report this to the garrow/elasticsearch17 tap!
```