### PR TITLE
Replace removed undent method with proper heredoc

### DIFF
--- a/HomebrewFormula/elasticsearch@1.7.rb
+++ b/HomebrewFormula/elasticsearch@1.7.rb
@@ -74,7 +74,7 @@ class ElasticsearchAT17 < Formula
 
   plist_options :manual => "elasticsearch --config=#{HOMEBREW_PREFIX}/opt/elasticsearch@1.7/config/elasticsearch.yml"
 
-  def plist; <<-EOS.undent
+  def plist; <<~EOS
       <?xml version="1.0" encoding="UTF-8"?>
       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
       <plist version="1.0">


### PR DESCRIPTION
Related to #1, the change needs to be done for the plist method as well - installing now throws errors and manually doing the conversion on my local file does allow it to install cleanly again.